### PR TITLE
RF: Split file checking from iteration, allow checking individual files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ $ miniqc tests/data/bids_dataset
 ]
 ```
 
+Single file usage is also permitted:
+
+```console
+$ miniqc tests/data/bids_dataset/sub-01/anat/sub-01_acq-truncated_T2w.nii.gz
+[
+  [
+    "/git/miniqc/tests/data/bids_dataset/sub-01/anat/sub-01_acq-truncated_T2w.nii.gz",
+    "FailedCheck",
+    "Expected 477 bytes; found 352"
+  ]
+]
+```
+
 ### Outputs
 
 The output of this tool is a JSON array of arrays, each of length 3.

--- a/changelog.d/20230618_155723_effigies_check_individual_files.rst
+++ b/changelog.d/20230618_155723_effigies_check_individual_files.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+Added
+-----
+
+- Accept individual files as inputs.
+
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/miniqc/__main__.py
+++ b/miniqc/__main__.py
@@ -71,7 +71,7 @@ def check_file(
     bids_dir: ty.Optional[Path] = None,
 ) -> list[tuple[str, str, str]]:
     for pattern, checklist in CHECKS:
-        if re.search(pattern, path.name):
+        if pattern.search(path.name):
             try:
                 fileobj = checklist.loader(path)
                 for check in checklist.checks:

--- a/miniqc/__main__.py
+++ b/miniqc/__main__.py
@@ -3,6 +3,7 @@ import os
 import re
 import typing as ty
 from enum import Enum
+from itertools import chain
 from pathlib import Path
 
 import nibabel as nb
@@ -13,7 +14,9 @@ from . import nifti
 from .types import CheckList, FailedCheck
 
 # Add to this list as file types are added
-SupportedType: TypeAlias = ty.Union[nb.Nifti1Image,]
+SupportedType: TypeAlias = ty.Union[
+    nb.Nifti1Image,
+]
 
 # Regex patterns paired with checklists to verify on file
 # To avoid multiple reads, only the first matching check is applied to each
@@ -44,34 +47,42 @@ def main(
         help='Ignore symlinks with missing targets',
     ),
 ) -> None:
-    errors = []
-    for root, dirs, files in os.walk(bids_dir):
-        dirs[:] = [d for d in dirs if not d[0] == '.']
-        root_path = Path(root)
-        for file in files:
-            for pattern, checklist in CHECKS:
-                if re.search(pattern, file):
-                    path = root_path / file
-                    try:
-                        fileobj = checklist.loader(path)
-                        for check in checklist.checks:
-                            result, message = check(fileobj)
-                            if not result:
-                                raise FailedCheck(message or check.__doc__)
-                    except Exception as e:
-                        if not allow_dangling_links or not isinstance(
-                            e, FileNotFoundError
-                        ):
-                            errors.append(
-                                (
-                                    str(path.relative_to(bids_dir)),
-                                    type(e).__name__,
-                                    str(e),
-                                )
-                            )
-                    break
+
+    # Allow to be used on individual files
+    if not bids_dir.is_dir():
+        errors = check_file(bids_dir)
+    else:
+        errors = []
+        for root, dirs, files in os.walk(bids_dir):
+            dirs[:] = [d for d in dirs if not d[0] == '.']
+            root_path = Path(root)
+            errors.extend(
+                chain.from_iterable(check_file(root_path / file, bids_dir) for file in files)
+            )
+
+    if allow_dangling_links:
+        errors = [err for err in errors if err[1] != 'FileNotFoundError']
     print(json.dumps(errors, indent=2))
     raise typer.Exit(code=len(errors) > 0)
+
+
+def check_file(
+    path: Path,
+    bids_dir: ty.Optional[Path] = None,
+) -> list[tuple[str, str, str]]:
+    for pattern, checklist in CHECKS:
+        if re.search(pattern, path.name):
+            try:
+                fileobj = checklist.loader(path)
+                for check in checklist.checks:
+                    result, message = check(fileobj)
+                    if not result:
+                        raise FailedCheck(message or check.__doc__)
+            except Exception as e:
+                if bids_dir is not None:
+                    path = path.relative_to(bids_dir)
+                return [(str(path), type(e).__name__, str(e))]
+    return []
 
 
 if __name__ == '__main__':

--- a/miniqc/nifti.py
+++ b/miniqc/nifti.py
@@ -23,9 +23,7 @@ def fullsize(img: nb.Nifti1Image) -> CheckResult:
     with dataobj._get_fileobj() as fobj:
         # Seek beyond end returns end position
         actual: int = fobj.seek(expected + 1)
-    return CheckResult(
-        (actual == expected, f'Expected {expected} bytes; found {actual}')
-    )
+    return CheckResult((actual == expected, f'Expected {expected} bytes; found {actual}'))
 
 
 CHECKS = CheckList(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,6 @@ exclude_lines = [
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
 ]
+
+[tool.blue]
+line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,7 @@ def good_nifti(example_dataset: Path) -> Path:
 
 @pytest.fixture(scope='session')
 def truncated_nifti(example_dataset: Path) -> Path:
-    return (
-        example_dataset / 'sub-01' / 'anat' / 'sub-01_acq-truncated_T2w.nii.gz'
-    )
+    return example_dataset / 'sub-01' / 'anat' / 'sub-01_acq-truncated_T2w.nii.gz'
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_nifti.py
+++ b/tests/test_nifti.py
@@ -25,9 +25,7 @@ def test_load_fail(example_dataset: Path) -> None:
         load(example_dataset / 'dataset_description.json')
 
 
-def test_fullsize(
-    good_nifti: Path, truncated_nifti: Path, good_nifti2: Path
-) -> None:
+def test_fullsize(good_nifti: Path, truncated_nifti: Path, good_nifti2: Path) -> None:
     # fullsize returns results if load succeeds
     good, message = fullsize(load(good_nifti))
     assert good


### PR DESCRIPTION
`walk` only works on directories, but you might just want to run this on a single file. This PR factors out file checking from the directory walk. If `bids_dir` is actually a file, we just check it once.

This also moves the `FileNotFound` filter into a post-hoc filter, rather than deep in the loop.