### PR TITLE
DOCKER: Use official numpy wheels, build with alpine

### DIFF
--- a/.github/workflows/hatch.yml
+++ b/.github/workflows/hatch.yml
@@ -46,12 +46,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
-      - name: Install Hatch
-        run: |
-          python -m pip install --upgrade pip
-          pip install hatch
       - name: Test
-        run: hatch run ${{ matrix.command }}
+        run: pipx run hatch run ${{ matrix.command }}
 
   build:
     runs-on: ubuntu-latest
@@ -62,9 +58,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3
-      - run: pip install --upgrade build twine
-      - run: python -m build
-      - run: twine check dist/*
+      - run: pipx run build
+      - run: pipx run twine check dist/*
       - uses: actions/upload-artifact@v3
         with:
           name: dist
@@ -88,16 +83,14 @@ jobs:
           python-version: 3
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
-      - name: Install Hatch
-        run: |
-          python -m pip install --upgrade pip
-          pip install hatch
       - name: Test
-        run: cd miniqc-* && hatch run test:no-cov
+        run: cd miniqc-* && pipx run hatch run test:no-cov
 
   publish:
     runs-on: ubuntu-latest
     needs: [test, test-sdist]
+    permissions:
+      id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v3
@@ -105,6 +98,3 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.11-slim as build-miniqc
-RUN pip install build
-RUN apt-get update && apt-get install -y --no-install-recommends git
+FROM python:3.11-alpine as build-miniqc
+RUN apk add git py3-build
 COPY . /src
-RUN python -m build /src
+RUN pyproject-build /src
 
 FROM python:3.11-alpine
 COPY --from=build-miniqc /src/dist/*.whl .
-RUN pip install --extra-index-url https://alpine-wheels.github.io/index --no-cache-dir $( ls *.whl ) \
+RUN pip install --no-cache-dir $( ls *.whl ) \
     && rm -rf ~/.cache
 
 ENTRYPOINT miniqc

--- a/changelog.d/20230618_162534_effigies_alpine.rst
+++ b/changelog.d/20230618_162534_effigies_alpine.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- Tweaked Dockerfile for faster build and smaller image.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..


### PR DESCRIPTION
As of numpy 1.25, musllinux wheels are pushed to PyPI, so we can stop using third-party wheels. This shaves an additional 20MB off the final image.

We can also speed up the build slightly by building on Alpine.