### PR TITLE
CI: Install multiple Python versions, consolidate jobs

### DIFF
--- a/.github/workflows/hatch.yml
+++ b/.github/workflows/hatch.yml
@@ -23,32 +23,6 @@ defaults:
     shell: 'bash'
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ['ubuntu-latest']
-        python-version: ['3.9', '3.10', '3.11']
-        command: ['test:no-cov']
-        include:
-          - os: 'ubuntu-latest'
-            python-version: '3'
-            command: 'test:cov'
-          - os: 'ubuntu-latest'
-            python-version: '3'
-            command: 'type:check'
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-      - name: Test
-        run: pipx run hatch run ${{ matrix.command }}
-
   build:
     runs-on: ubuntu-latest
     steps:
@@ -65,30 +39,37 @@ jobs:
           name: dist
           path: dist/
 
-  test-sdist:
-    runs-on: ${{ matrix.os }}
+  test:
+    runs-on: 'ubuntu-latest'
     needs: [build]
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        source: ['repo', 'sdist']
     steps:
+      - uses: actions/checkout@v3
+        if: matrix.source == 'repo'
       - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/
+        if: matrix.source == 'sdist'
       - name: Unpack sdist
-        run: tar xfvz dist/*.tar.gz
+        run: tar --strip-components=1 -xvzf dist/*.tar.gz
+        if: matrix.source == 'sdist'
       - uses: actions/setup-python@v4
         with:
-          python-version: 3
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
+          python-version: |
+            3.9
+            3.10
+            3.11
       - name: Test
-        run: cd miniqc-* && pipx run hatch run test:no-cov
+        run: |
+          pipx run hatch run test:cov
+          pipx run hatch run type:check
 
   publish:
     runs-on: ubuntu-latest
-    needs: [test, test-sdist]
+    needs: [test]
     permissions:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/hatch.yml
+++ b/.github/workflows/hatch.yml
@@ -29,9 +29,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3
       - run: pipx run build
       - run: pipx run twine check dist/*
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/hatch.yml
+++ b/.github/workflows/hatch.yml
@@ -37,11 +37,15 @@ jobs:
           path: dist/
 
   test:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ matrix.os }}
     needs: [build]
     strategy:
       matrix:
-        source: ['repo', 'sdist']
+        os: ['ubuntu-latest', 'windows-latest']
+        source: ['repo']
+        include:
+          - os: ubuntu-latest
+            source: sdist
     steps:
       - uses: actions/checkout@v3
         if: matrix.source == 'repo'

--- a/changelog.d/20230618_201200_effigies_consolidate.rst
+++ b/changelog.d/20230618_201200_effigies_consolidate.rst
@@ -1,0 +1,36 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- Streamline CI configuration, testing multiple Python versions in each
+  job.
+- Test on Windows, normalize paths to POSIX for reporting.
+
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/miniqc/__main__.py
+++ b/miniqc/__main__.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import posixpath
 import typing as ty
 from enum import Enum
 from itertools import chain
@@ -66,6 +67,11 @@ def main(
     raise typer.Exit(code=len(errors) > 0)
 
 
+def unix_format(pathlike: os.PathLike) -> str:
+    """Format any pathlike in POSIX style (forward-slashes)."""
+    return posixpath.join(*Path(pathlike).parts)
+
+
 def check_file(
     path: Path,
     bids_dir: ty.Optional[Path] = None,
@@ -81,7 +87,7 @@ def check_file(
             except Exception as e:
                 if bids_dir is not None:
                     path = path.relative_to(bids_dir)
-                return [(str(path), type(e).__name__, str(e))]
+                return [(unix_format(path), type(e).__name__, str(e))]
     return []
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
+  "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
GitHub can install multiple Python versions, and hatch will discover any available. Consolidate test jobs to repo or sdist sources.

Add a Windows CI job and normalizes paths to posix for consistent output in Windows and Linux.

Add "OS Independent" to classifiers.